### PR TITLE
Detect when changes have been made to a gem repo since the last version bump, and group messages by team

### DIFF
--- a/lib/version_checker.rb
+++ b/lib/version_checker.rb
@@ -12,13 +12,12 @@ class VersionChecker
   def print_version_discrepancies
     discrepancies_found = false
 
-    fetch_all_govuk_gemspecs.each do |gemspec|
-      rubygems_version = fetch_rubygems_version(gemspec.name)
-      unless gemspec.version == rubygems_version
+    fetch_all_govuk_gems.each do |gem|
+      repo_name = gem["app_name"]
+      rubygems_version = fetch_rubygems_version(repo_name)
+      if files_changed_since_tag(repo_name, "v" + rubygems_version).any? { |path| path_is_built_into_gem?(path) }
         discrepancies_found = true
-        puts "Version mismatch for '#{gemspec.name}':"
-        puts "  Version on RubyGems: #{rubygems_version}"
-        puts "  Version on GitHub: #{gemspec.version}"
+        puts "#{repo_name} (owned by #{gem["team"]}) has unreleased changes since v#{rubygems_version}"
       end
     end
 
@@ -27,15 +26,14 @@ class VersionChecker
     end
   end
 
-  def fetch_all_govuk_gemspecs
+  def fetch_all_govuk_gems
     uri = URI("https://docs.publishing.service.gov.uk/gems.json")
     res = Net::HTTP.get_response(uri)
-
-    raise HttpError unless res.is_a?(Net::HTTPSuccess)
-
-    JSON.parse(res.body)
-      .map { |gem| fetch_gemspec(gem["app_name"]) }
-      .compact
+    if res.is_a?(Net::HTTPSuccess)
+      JSON.parse(res.body)
+    else
+      raise HttpError
+    end
   end
 
   def fetch_rubygems_version(gem_name)
@@ -47,21 +45,18 @@ class VersionChecker
     JSON.parse(res.body)['version']
   end
 
-  def fetch_gemspec(repo_name)
+  def files_changed_since_tag(repo, tag)
     Dir.mktmpdir do |path|
       Dir.chdir(path) do
-        clone_github_repo(repo_name)
-        gemspecs = Dir.glob("*.gemspec", base: repo_name)
-        if gemspecs.count == 1
-          Gem::Specification::load("#{repo_name}/#{gemspecs.first}")
-        else
-          nil
+        `git clone --recursive --depth 1 --shallow-submodules --no-single-branch git@github.com:alphagov/#{repo}.git > /dev/null 2>&1`
+        Dir.chdir(repo) do
+          `git diff --name-only #{tag}`.split("\n")
         end
       end
     end
   end
 
-  def clone_github_repo(name)
-    `git clone --recursive --depth 1 --shallow-submodules git@github.com:alphagov/#{name}.git > /dev/null 2>&1`
+  def path_is_built_into_gem?(path)
+    path.end_with?(".gemspec") || path.start_with?("app/", "lib/")
   end
 end

--- a/spec/example.gemspec
+++ b/spec/example.gemspec
@@ -1,7 +1,0 @@
-Gem::Specification.new do |s|
-  s.name        = 'example'
-  s.version     = "1.2.3"
-  s.authors     = ["Ruby Coder"]
-  s.files       = ["lib/example.rb"]
-  s.summary     = "This is an example!"
-end

--- a/spec/version_checker_spec.rb
+++ b/spec/version_checker_spec.rb
@@ -4,49 +4,33 @@ require 'version_checker'
 require 'base64'
 
 RSpec.describe VersionChecker do
-  let(:example_gemspec_path) { File.join(__dir__, "example.gemspec") }
-
   it 'fetches version number of a gem from rubygems' do
     stub_rubygems_call('6.0.1')
 
     expect(subject.fetch_rubygems_version('example')).to eq('6.0.1')
   end
 
-  it 'fetches version number of a gem from GitHub' do
-    stub_github_call
-
-    expect(subject.fetch_gemspec('example').version).to eq('1.2.3')
-  end
-
-  it "fetches gemspecs for all govuk repos" do
+  it "detects when there are no files changed since the last release that are built into the gem" do
     stub_devdocs_call
-    stub_github_call
-
-    expect(subject.fetch_all_govuk_gemspecs).to eq([Gem::Specification.load(example_gemspec_path)])
-  end
-
-  it "detects when there are no version discrepancies" do
-    stub_devdocs_call
-    stub_github_call
     stub_rubygems_call('1.2.3')
+    stub_files_changed_since_tag(["README.md"])
 
     expect { subject.print_version_discrepancies }.to output("No discrepancies found!\n").to_stdout
   end
 
-  it "detects when there are are version discrepancies" do
+  it "detects when there are files changed since the last release that are built into the gem" do
     stub_devdocs_call
-    stub_github_call
     stub_rubygems_call('1.2.2')
+    stub_files_changed_since_tag(["lib/foo.rb"])
 
     expect { subject.print_version_discrepancies }.to output(
-      "Version mismatch for 'example':\n  Version on RubyGems: 1.2.2\n  Version on GitHub: 1.2.3\n"
+      "example (owned by #platform-security-reliability-team) has unreleased changes since v1.2.2\n"
     ).to_stdout
   end
 
-  def stub_github_call
-    allow(subject).to receive(:clone_github_repo) do
-      FileUtils.mkdir "example"
-      FileUtils.cp example_gemspec_path, File.join(Dir.pwd, "example")
+  def stub_files_changed_since_tag(files)
+    allow(subject).to receive(:files_changed_since_tag) do
+      files
     end
   end
 
@@ -57,7 +41,7 @@ RSpec.describe VersionChecker do
   end
 
   def stub_devdocs_call
-    repo = [{ "app_name": "example" }]
+    repo = [{ "app_name": "example", "team": "#platform-security-reliability-team" }]
     stub_request(:get, 'https://docs.publishing.service.gov.uk/gems.json')
       .to_return(status: 200, body: repo.to_json, headers: {})
   end

--- a/spec/version_checker_spec.rb
+++ b/spec/version_checker_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe VersionChecker do
     stub_rubygems_call('1.2.3')
     stub_files_changed_since_tag(["README.md"])
 
-    expect { subject.print_version_discrepancies }.to output("No discrepancies found!\n").to_stdout
+    expect { subject.print_version_discrepancies }.to output("#platform-security-reliability-team\n\n").to_stdout
   end
 
   it "detects when there are files changed since the last release that are built into the gem" do
@@ -24,7 +24,7 @@ RSpec.describe VersionChecker do
     stub_files_changed_since_tag(["lib/foo.rb"])
 
     expect { subject.print_version_discrepancies }.to output(
-      "example (owned by #platform-security-reliability-team) has unreleased changes since v1.2.2\n"
+      "#platform-security-reliability-team\n  example has unreleased changes since v1.2.2\n"
     ).to_stdout
   end
 


### PR DESCRIPTION
https://trello.com/c/LMd1m6rj/3415-update-gem-release-alert-app-to-detect-when-changes-have-been-made-to-a-gem-repo-since-the-last-version-bump

