### PR TITLE
Fix bug affecting GitHub Actions

### DIFF
--- a/lib/version_checker.rb
+++ b/lib/version_checker.rb
@@ -46,9 +46,13 @@ class VersionChecker
   def files_changed_since_tag(repo, tag)
     Dir.mktmpdir do |path|
       Dir.chdir(path) do
-        `git clone --recursive --depth 1 --shallow-submodules --no-single-branch git@github.com:alphagov/#{repo}.git > /dev/null 2>&1`
-        Dir.chdir(repo) do
-          `git diff --name-only #{tag}`.split("\n")
+        if system("git clone --recursive --depth 1 --shallow-submodules --no-single-branch https://github.com/alphagov/#{repo}.git > /dev/null 2>&1")
+          Dir.chdir(repo) do
+            `git diff --name-only #{tag}`.split("\n")
+          end
+        else
+          puts "Warning: Failed to clone #{repo}"
+          []
         end
       end
     end


### PR DESCRIPTION
Issue came up after latest PR was merged, which prevents the script
from executing properly. Previously, we were cloning repos over SSH, but GH Actions runners have no SSH keys. This caused every git clone to fail. We now use http instead, which requires no authentication.

Also added better error checking.