### PR TITLE
Slack message implementation

### DIFF
--- a/.github/workflows/version_checker.yml
+++ b/.github/workflows/version_checker.yml
@@ -3,7 +3,10 @@ name: "Gem Version Checker"
 on:
   workflow_dispatch: {}
   schedule:
-    - cron:  '00 10 * * 1-5' # Runs at 10:00, Monday through Friday.
+    - cron:  '00 13 * * 3' # Runs at 13:00, Every Wednesday.
+
+env:
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
 jobs:
   gem-version-checker:

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "octokit"
 gem "rake"
+gem "slack-poster"
 gem "webmock"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    slack-poster (2.2.2)
+      faraday (>= 1.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -117,6 +119,7 @@ DEPENDENCIES
   rake
   rspec
   rubocop-govuk
+  slack-poster
   webmock
 
 BUNDLED WITH

--- a/lib/version_checker.rb
+++ b/lib/version_checker.rb
@@ -4,6 +4,7 @@ require "uri"
 require "net/http"
 require "json"
 require "octokit"
+require "slack/poster"
 
 class HttpError < RuntimeError
 end
@@ -11,20 +12,35 @@ end
 class VersionChecker
   GEMS_API = URI("https://docs.publishing.service.gov.uk/gems.json")
 
+  def slack_options(team)
+    {
+      icon_emoji: ":gem:",
+      username: "Gem Release Bot",
+      channel: team.to_s,
+    }
+  end
+
   def print_version_discrepancies
     all_govuk_gems.group_by { |gem| gem["team"] }.each do |team, gems|
-      message = gems.filter_map { |gem|
-        repo_name = gem["app_name"]
-        rubygems_version = fetch_rubygems_version(repo_name)
-        if !rubygems_version.nil? &&
-            files_changed_since_tag(repo_name, "v#{rubygems_version}").any? { |path| path_built_into_gem?(path) }
-          "  #{repo_name} has unreleased changes since v#{rubygems_version}"
-        end
-      }.join("\n")
+      message = message_builder(gems)
 
-      puts team
-      puts message
+      puts "team: #{team}\n#{message}"
+
+      poster = Slack::Poster.new(ENV["SLACK_WEBHOOK"], slack_options(team))
+      poster.send_message(message.to_s) unless message.nil?
     end
+  end
+
+  def message_builder(gems)
+    gems.filter_map { |gem|
+      repo_name = gem["app_name"]
+      repo_url = gem["links"]["repo_url"]
+      rubygems_version = fetch_rubygems_version(repo_name)
+      if !rubygems_version.nil? &&
+          files_changed_since_tag(repo_name, "v#{rubygems_version}").any? { |path| path_built_into_gem?(path) }
+        "  <#{repo_url}|#{repo_name}> has unreleased changes since v#{rubygems_version}"
+      end
+    }.join("\n")
   end
 
   def all_govuk_gems

--- a/lib/version_checker.rb
+++ b/lib/version_checker.rb
@@ -38,7 +38,7 @@ class VersionChecker
       rubygems_version = fetch_rubygems_version(repo_name)
       if !rubygems_version.nil? &&
           files_changed_since_tag(repo_name, "v#{rubygems_version}").any? { |path| path_built_into_gem?(path) }
-        "  <#{repo_url}|#{repo_name}> has unreleased changes since v#{rubygems_version}"
+        "<#{repo_url}|#{repo_name}> has unreleased changes since v#{rubygems_version}"
       end
     }.join("\n")
   end

--- a/lib/version_checker.rb
+++ b/lib/version_checker.rb
@@ -27,7 +27,7 @@ class VersionChecker
       puts "team: #{team}\n#{message}"
 
       poster = Slack::Poster.new(ENV["SLACK_WEBHOOK"], slack_options(team))
-      poster.send_message(message.to_s) unless message.nil?
+      poster.send_message(message.to_s) unless message.empty?
     end
   end
 

--- a/spec/version_checker_spec.rb
+++ b/spec/version_checker_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe VersionChecker do
   end
 
   it "detects when there are no files changed since the last release that are built into the gem" do
-    stub_slack_poster_call_with_no_changes
     stub_devdocs_call
     stub_rubygems_call("1.2.3")
     stub_files_changed_since_tag(["README.md"])
@@ -64,19 +63,5 @@ RSpec.describe VersionChecker do
       body: { "payload" => "{\"icon_emoji\":\":gem:\",\"username\":\"Gem Release Bot\",\"channel\":\"#platform-security-reliability-team\",\"text\":\"<https://example.com|example> has unreleased changes since v1.2.2\"}" },
     )
     .to_return(status: 200)
-  end
-
-  def stub_slack_poster_call_with_no_changes
-    stub_request(:post, "https://slack/webhook")
-         .with(
-           body: { "payload" => "{\"icon_emoji\":\":gem:\",\"username\":\"Gem Release Bot\",\"channel\":\"#platform-security-reliability-team\",\"text\":\"\"}" },
-           headers: {
-             "Accept" => "*/*",
-             "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-             "Content-Type" => "application/x-www-form-urlencoded",
-             "User-Agent" => "Faraday v2.7.11",
-           },
-         )
-         .to_return(status: 200, body: "", headers: {})
   end
 end

--- a/spec/version_checker_spec.rb
+++ b/spec/version_checker_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe VersionChecker do
     stub_files_changed_since_tag(["lib/foo.rb"])
 
     expect { version_checker.print_version_discrepancies }.to output(
-      "team: #platform-security-reliability-team\n  <https://example.com|example> has unreleased changes since v1.2.2\n",
+      "team: #platform-security-reliability-team\n<https://example.com|example> has unreleased changes since v1.2.2\n",
     ).to_stdout
   end
 
@@ -61,15 +61,9 @@ RSpec.describe VersionChecker do
   def stub_slack_poster_call_with_changes
     stub_request(:post, "https://slack/webhook")
     .with(
-      body: { "payload" => "{\"icon_emoji\":\":gem:\",\"username\":\"Gem Release Bot\",\"channel\":\"#platform-security-reliability-team\",\"text\":\"  <https://example.com|example> has unreleased changes since v1.2.2\"}" },
-      headers: {
-        "Accept" => "*/*",
-        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-        "Content-Type" => "application/x-www-form-urlencoded",
-        "User-Agent" => "Faraday v2.7.11",
-      },
+      body: { "payload" => "{\"icon_emoji\":\":gem:\",\"username\":\"Gem Release Bot\",\"channel\":\"#platform-security-reliability-team\",\"text\":\"<https://example.com|example> has unreleased changes since v1.2.2\"}" },
     )
-    .to_return(status: 200, body: "", headers: {})
+    .to_return(status: 200)
   end
 
   def stub_slack_poster_call_with_no_changes


### PR DESCRIPTION
These changes add and configure Slack Poster to the application, so it notifies the owners of the affected gems via their team's Slack channels.

https://trello.com/c/bJPe832u/3388-update-gem-release-alert-app-to-send-messages-to-slack