### PR TITLE
Tweak "is this a substantial change?" heuristic

### DIFF
--- a/lib/version_checker.rb
+++ b/lib/version_checker.rb
@@ -75,6 +75,6 @@ class VersionChecker
   end
 
   def path_built_into_gem?(path)
-    path.end_with?(".gemspec") || path.start_with?("app/", "lib/")
+    path.start_with?("app/", "lib/") || path == "CHANGELOG.md"
   end
 end

--- a/lib/version_checker.rb
+++ b/lib/version_checker.rb
@@ -36,8 +36,7 @@ class VersionChecker
       repo_name = gem["app_name"]
       repo_url = gem["links"]["repo_url"]
       rubygems_version = fetch_rubygems_version(repo_name)
-      if !rubygems_version.nil? &&
-          files_changed_since_tag(repo_name, "v#{rubygems_version}").any? { |path| path_built_into_gem?(path) }
+      if !rubygems_version.nil? && change_is_significant?(repo_name, rubygems_version)
         "<#{repo_url}|#{repo_name}> has unreleased changes since v#{rubygems_version}"
       end
     }.join("\n")
@@ -74,7 +73,9 @@ class VersionChecker
     end
   end
 
-  def path_built_into_gem?(path)
-    path.start_with?("app/", "lib/") || path == "CHANGELOG.md"
+  def change_is_significant?(repo_name, previous_version)
+    files_changed_since_tag(repo_name, "v#{previous_version}").any? do |path|
+      path.start_with?("app/", "lib/") || path == "CHANGELOG.md"
+    end
   end
 end


### PR DESCRIPTION
We're currently nagging devs too much (3 of the 5 repos this bot is notifying us about don't have changes substantial enough to bother releasing). Let's tweak the heuristic we use to decide if a change is important enough to nag about:

* Don't consider changes to the gemspec (because these are often just changes to dev dependencies)
* Consider changes to the changelog (if a dev considers them important enough to include in the changelog then they're probably important enough to release)